### PR TITLE
Change dead google code images url to new github url

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1611,7 +1611,7 @@ MarkerClusterer.BATCH_SIZE_IE = 500;
  * @type {string}
  * @constant
  */
-MarkerClusterer.IMAGE_PATH = "http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+MarkerClusterer.IMAGE_PATH = "https://raw.githubusercontent.com/googlemaps/v3-utility-library/master/markerclustererplus/images/m";
 
 
 /**


### PR DESCRIPTION
Images urls pointing to their old library no longer work, and have to be changed, e.g.:

`http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m2.png`
<img src="http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m2.png"/>

to
`https://raw.githubusercontent.com/googlemaps/v3-utility-library/master/markerclustererplus/images/m2.png`

<img src="https://raw.githubusercontent.com/googlemaps/v3-utility-library/master/markerclustererplus/images/m2.png"/>
