### PR TITLE
Bump package.json version so URL fix can be installed via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marker-clusterer-plus",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Clone of markerclustererplus, but works with npm out of the box",
   "keywords": [
     "google-marker-clusterer-plus",


### PR DESCRIPTION
Sorry, forgot to include this in https://github.com/mikesaidani/marker-clusterer-plus/pull/2
