### PR TITLE
Allow `imagePath` option to be an array

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -800,9 +800,15 @@ MarkerClusterer.prototype.setupStyles_ = function () {
   }
 
   for (i = 0; i < this.imageSizes_.length; i++) {
+    var url;
+    if(Object.prototype.toString.call(this.imagePath_) === '[object Array]') {
+      url = this.imagePath_[i]
+    } else {
+      url = this.imagePath_ + (i + 1) + "." + this.imageExtension_
+    }
     size = this.imageSizes_[i];
     this.styles_.push({
-      url: this.imagePath_ + (i + 1) + "." + this.imageExtension_,
+      url: url,
       height: size,
       width: size
     });


### PR DESCRIPTION
Allow for more fine grained control for marker icons. This allows you to set specific icon files, instead of just the directory.

I personally want this feature, because then I can set my markers to be inline base64 encoded images. 